### PR TITLE
Remove unused imports

### DIFF
--- a/custom_components/jarolift/cover.py
+++ b/custom_components/jarolift/cover.py
@@ -10,8 +10,6 @@ from homeassistant.components.cover import (
     PLATFORM_SCHEMA,
     CoverDeviceClass,
     CoverEntity,
-    STATE_OPEN,
-    STATE_CLOSED,
 )
 
 from homeassistant.const import CONF_NAME


### PR DESCRIPTION
These unused imports have been removed from Home Assistant 2025.11.0 and will cause the integration to fail loading. See home-assistant/core#154037